### PR TITLE
Support servers with password set but no username

### DIFF
--- a/common.js
+++ b/common.js
@@ -8,8 +8,8 @@ function rpcCall (meth, args) {
 			'Content-Type': 'application/json',
 			'x-transmission-session-id': server.session,
 		}
-		if (server.username !== '') {
-			myHeaders['Authorization'] = 'Basic ' + btoa(server.username + ':' + server.password)
+		if (server.username !== '' || server.password !== '') {
+			myHeaders['Authorization'] = 'Basic ' + btoa((server.username || '') + ':' + (server.password || ''))
 		}
 		return fetch(server.base_url + 'rpc', {
 			method: 'POST',


### PR DESCRIPTION
In case the server in question does not have a username set the password field in the settings would be ignored.

This small change should make the extension try to authenticate when either username or password are set in the settings.