### PR TITLE
Fix bug when badge is changed back to nothing, remove unnecessary timer

### DIFF
--- a/background.js
+++ b/background.js
@@ -133,7 +133,9 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 
 function updateBadge () {
 	browser.storage.local.get('server').then(({server}) => {
-		if (server.badge !== 'num' && server.badge !== 'dl' && server.badge !== 'ul' && server.badge !== 'auto') {
+		if (!server || server.badge === 'off') {
+			browser.browserAction.setBadgeBackgroundColor({color: 'gray'})
+			browser.browserAction.setBadgeText({text: ''})
 			return
 		}
 		return rpcCall('session-stats', {}).then(response => {
@@ -177,12 +179,11 @@ browser.alarms.onAlarm.addListener(alarm => {
 function setupBadge () {
 	browser.alarms.clear('transmitter-badge-update').then(x => {
 		browser.storage.local.get('server').then(({server}) => {
-			if (!server) {
-				return
+			if (server && server.badge !== 'off') {
+				browser.alarms.create('transmitter-badge-update', {
+					periodInMinutes: parseInt(server.badge_interval || '1')
+				})
 			}
-			browser.alarms.create('transmitter-badge-update', {
-				periodInMinutes: parseInt(server.badge_interval || '1')
-			})
 			updateBadge()
 		})
 	})


### PR DESCRIPTION
Prior to this, if the badge icon was showing some data and then the setting was changed to off/nothing, it would continue showing the old data.

Additionally, the background alarm would be set even if the badge was set to off/nothing. It now only configures the alarm when the badge needs to be updated.

Fixes https://github.com/myfreeweb/transmitter/issues/31