### PR TITLE
dark mode css for options

### DIFF
--- a/options.css
+++ b/options.css
@@ -45,3 +45,32 @@ button {
 		flex: 2;
 	}
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #f9f9fa;
+    background: #202023;
+  }
+
+  form > label {
+	color: #f9f9fa;
+	text-shadow: 0 1px 1px #b1b1b3;
+	border-bottom: #4c4c4e;
+  }
+
+  input, select, option {
+	  color: #f9f9fa;
+	  background-color: #2a2a2e;
+	  border-color: #4c4c4e;
+  }
+
+  fieldset {
+	  border-color: #4c4c4e;
+  }
+
+  button {
+	  color: #f9f9fa;
+	  background-color: #373739;
+	  border-color: #4c4c4e;
+  }
+}


### PR DESCRIPTION
Seeing it in white is pretty jarring when the rest of the settings page is dark. Colors were matched to Firefox in dark mode.

<img width="758" alt="Screen Shot 2020-11-18 at 5 17 56 PM" src="https://user-images.githubusercontent.com/114976/99595069-148b4d80-29c2-11eb-9642-790defcdbd60.png">

I didn't do the popup. Mostly because I'm out of time, but also it's supposed to stand out.